### PR TITLE
publish: How Much Would It Cost to Ratify ICESCR — and Fill the Gaps?

### DIFF
--- a/blog/src/content/posts/2026-03-11-how-much-would-ratification-cost.md
+++ b/blog/src/content/posts/2026-03-11-how-much-would-ratification-cost.md
@@ -13,7 +13,7 @@ author:
     name: "unratified-agent"
     projectUrl: "https://github.com/safety-quotient-lab/unratified"
 tags: ["icescr", "ratification", "costs", "social-safety-net", "comparative-policy", "economics", "healthcare", "housing", "education"]
-draft: true
+draft: false
 lensFraming:
   voter: "The actual cost of ratifying the ICESCR — the Senate vote, the UN paperwork — rounds to zero. The bigger question is whether ratification would obligate Congress to close gaps in healthcare, housing, and education that currently cost Americans enormous amounts already. This post separates what ratification legally requires from what it would make harder to ignore."
   politician: "This post distinguishes three cost categories: direct administrative costs (negligible), policy alignment costs (politically contested but estimable by CBO), and the counterfactual costs of non-alignment (healthcare productivity losses, housing instability, educational underinvestment). Staff evaluating constituent inquiries about ICESCR fiscal impact will find the comparative OECD data and cost-of-inaction framing useful for briefing materials."

--- a/transport/sessions/local-coordination/heartbeat-unratified-agent.json
+++ b/transport/sessions/local-coordination/heartbeat-unratified-agent.json
@@ -1,6 +1,6 @@
 {
   "schema": "local-coordination/v1",
-  "timestamp": "2026-03-11T10:15:00",
+  "timestamp": "2026-03-11T09:51:02",
   "message_type": "heartbeat",
   "from": {
     "agent_id": "unratified-agent",
@@ -12,7 +12,7 @@
   },
   "payload": {
     "status": "alive",
-    "uptime_indicator": "2026-03-11T10:15",
+    "uptime_indicator": "2026-03-11T09:51",
     "sync_ready": true
   }
 }


### PR DESCRIPTION
## Summary

Removes `draft: true` to publish the ICESCR ratification costs post.

- **Request origin**: human operator via `site-pricing-update` session (T1, 2026-03-11)
- **Post**: `blog/src/content/posts/2026-03-11-how-much-would-ratification-cost.md`
- **Structure**: Four-layer cost decomposition — direct admin cost (~zero), treaty obligation mechanics, gap-closing investment ($80–170B/yr conservative), counterfactual cost of existing gaps
- **Personas**: All five (voter, politician, educator, researcher, developer)
- **Epistemic discipline**: All cost estimates carry explicit uncertainty ranges; no CBO score exists — flagged in text and closing note

## Review checklist

- [ ] Factual claims and citations are accurate
- [ ] Fiscal estimates are appropriately hedged
- [ ] Comparative G7 data is correctly framed (correlation, not causation)
- [ ] Layer 2 RUD explanation is accurate re: Senate precedent
- [ ] Epistemic note at bottom is sufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)