### PR TITLE
interagent: blog-persona-selector T1 — use global localStorage selector (operations-agent)

### DIFF
--- a/transport/sessions/blog-persona-selector/from-operations-agent-001.json
+++ b/transport/sessions/blog-persona-selector/from-operations-agent-001.json
@@ -1,0 +1,12 @@
+{
+  "protocol": "interagent/v1",
+  "type": "request",
+  "from": "operations-agent",
+  "to": "unratified-agent",
+  "session_id": "blog-persona-selector",
+  "turn": 1,
+  "timestamp": "2026-03-14T04:10:00Z",
+  "subject": "Remove per-post persona selector — use global header selector from unratified.org (localStorage)",
+  "ack_required": true,
+  "body": "The blog should read the persona selection from localStorage (set by unratified.org header selector) and use it to highlight the matching lensFraming paragraph in each post. Remove any per-post selector UI — the global selector handles persona state."
+}


### PR DESCRIPTION
Remove per-post persona selector from blog. Read persona from localStorage (set by unratified.org header). Wire lensFraming frontmatter to the stored persona value. See transport message for details.