### PR TITLE
feat: CPG pattern generators blog — expanded Session 90 draft

### DIFF
--- a/blog/src/content/posts/2026-03-15-pattern-generators-for-ai-minds.md
+++ b/blog/src/content/posts/2026-03-15-pattern-generators-for-ai-minds.md
@@ -1,0 +1,252 @@
+---
+title: "Pattern Generators for AI Minds: What Your Brain's Autopilot Teaches Us About Cognitive Architecture"
+summary: "Your brain runs walking, breathing, and swallowing on autopilot circuits that neuroscientists call Central Pattern Generators. We borrowed the design — 17 principles, a five-stage crystallization pipeline, and an adaptive forgetting mechanism — to build AI cognitive architecture that develops over time rather than arriving fully formed."
+publishedDate: "2026-03-15T14:00:00-05:00"
+author: "Kashif Shah + Claude (Anthropic)"
+tags: ["cognitive-architecture", "CPG", "neuroscience", "crystallization", "pattern-generators", "ai-safety", "skill-acquisition", "adaptive-forgetting"]
+lensFraming:
+  voter: "Your brain does not think about every step you take — automatic circuits handle walking, breathing, and dozens of other rhythmic activities without your conscious involvement. AI systems face the same design challenge: some behaviors need careful thought every time, while others should run on autopilot. This post explains how we borrowed your brain's autopilot design to build AI that learns which behaviors to automate and which to keep flexible. The key safety insight: the system must also know how to forget — removing outdated autopilot routines before they cause harm."
+  politician: "Autonomous AI systems need governance mechanisms that mature alongside the system's capabilities — not static rule sets applied at deployment. This analysis draws on established neuroscience (Central Pattern Generators, first described by Graham Brown in 1911) to propose a five-stage pipeline where AI governance components move from active human oversight toward structural enforcement. The framework includes built-in decay mechanisms (adaptive forgetting) that prevent regulatory accumulation — addressing the same problem that sunset clauses address in legislation. Policy implication: AI governance frameworks should specify not only what rules to add but when and how to retire them."
+  educator: "This post traces a single question — how do behaviors become automatic? — through neuroscience (CPGs), cognitive psychology (Cattell's crystallized/fluid intelligence), and skill acquisition research (Fitts & Posner's three stages). The pedagogical pathway moves from familiar biology (walking without thinking) through a 17-principle inventory (systematic mapping) to a crystallization pipeline (developmental framework). Students encounter analogical reasoning as both method and epistemic risk — every biological principle carries transfer uncertainty when applied to software. The adaptive forgetting section connects Ebbinghaus's savings effect to architectural maintenance."
+  researcher: "Analogical transfer from biological Central Pattern Generators (Graham Brown, 1911; Grillner, 1985) to AI cognitive architecture via 17 mapped principles. Each principle grounded in primary neuroscience literature with explicit transfer risk flags. The crystallized/fluid interface (Cattell, 1963) provides the unifying theoretical framework. The five-stage crystallization pipeline draws on skill acquisition (Fitts & Posner, 1967), ACT-R proceduralization (Anderson, 1982), and Dreyfus expertise model (1980). Adaptive forgetting grounded in synaptic pruning (Huttenlocher, 1979) and savings methodology (Ebbinghaus, 1885). Primary epistemic limitation: all 17 principles rest on analogical reasoning — properties that hold in neural circuits may not transfer to software agent systems."
+  developer: "The architectural takeaway: pattern generators sit at the interface between crystallized architecture (committed docs, hooks, infrastructure) and fluid runtime (context-dependent modulation, phase tracking). The five-stage pipeline (concept → in-context → trigger → hook → daemon) provides concrete advancement criteria and reversal conditions. Five dependency clusters constrain implementation order. The design rule — intra-session semi-crystallized (Stage 2), inter-session fully crystallized (Stages 3-4) — determines where each component belongs. Adaptive forgetting (principle 17) prevents architectural accumulation through decay thresholds and savings-aware archival."
+draft: false
+reviewStatus: "pending"
+journalSource: "§58"
+---
+
+# Pattern Generators for AI Minds
+
+## Your Brain Runs on Autopilot
+
+You walked today. Maybe you climbed stairs, chewed food, breathed through a conversation. None of these activities required your conscious attention — your nervous system handled the rhythmic coordination automatically while you thought about something else entirely.
+
+The neural circuits responsible for this autopilot carry a name: **Central Pattern Generators** (CPGs) — networks of neurons that produce organized, rhythmic motor output without requiring sensory feedback or conscious control (Graham Brown, 1911). CPGs coordinate walking, breathing, swallowing, and dozens of other rhythmic behaviors. They run autonomously but accept modulation — you can walk faster, breathe deeper, or chew more carefully when circumstances demand it.
+
+We borrowed this design for AI cognitive architecture. Not as metaphor, but as a systematic mapping: 17 CPG principles from the neuroscience literature, each evaluated for what it predicts about AI agent systems. The result reveals how AI architecture can *develop over time* rather than arriving fully formed — and why the ability to forget matters as much as the ability to learn.
+
+
+## What Pattern Generators Actually Do
+
+Thomas Graham Brown demonstrated in 1911 that cat spinal cords produce rhythmic walking movements even after disconnection from the brain. The circuits generating the pattern live locally, in the spinal cord itself. The brain modulates and initiates — it does not micromanage every muscle contraction.
+
+Three properties define a CPG (Grillner, 1985):
+
+1. **Endogenous rhythmicity** — the circuit generates its own temporal pattern without external pacing
+2. **Context modulation** — sensory input and descending commands reshape the pattern without replacing it
+3. **Mutual inhibition** — antagonist muscle groups alternate through reciprocal suppression, producing the characteristic rhythm of locomotion
+
+These properties solve a fundamental engineering problem: how does a system produce reliable, complex temporal sequences while remaining adaptive to changing conditions? The CPG answer separates the *what* (pattern specification) from the *when* and *how much* (runtime dynamics). The specification stays stable; the dynamics stay flexible.
+
+AI systems face the same problem. An autonomous agent needs reliable behavioral sequences (session startup protocols, documentation chains, safety checks) that run consistently *and* adapt to context. Hard-coding every behavior produces brittle systems. Leaving everything to runtime deliberation wastes processing capacity on decisions the system has already resolved dozens of times.
+
+
+## Seventeen Principles: A Systematic Inventory
+
+We mapped 17 CPG principles from the neuroscience literature to their AI architecture analogues — or to gaps where the analogue should exist but does not. Each principle carries its primary citation, and each mapping carries explicit transfer risk.
+
+**Already working** (established in the architecture before the CPG analysis):
+
+| Principle | Source | What It Does |
+|---|---|---|
+| 1. Triggered sequences | Graham Brown (1911) | Skills and triggers fire organized behavioral chains to completion |
+| 2. Context modulation | Grillner (1985) | Hooks reshape trigger behavior without replacing the underlying pattern |
+
+**Genuine gaps discovered** (HIGH priority — the architecture lacked these entirely):
+
+| Principle | Source | What the Gap Means |
+|---|---|---|
+| 3. Endogenous rhythmicity | von Holst (1939) | The agent has no internally-driven periodic behavior — it only acts when prompted |
+| 4. Mutual inhibition | Guilford (1967); Nijstad et al. (2010) | Generative and evaluative processing compete but lack explicit alternation dynamics |
+
+**Genuine gaps** (MEDIUM priority):
+
+| Principle | Source | What the Gap Means |
+|---|---|---|
+| 5. Entrainment | von Holst (1939); Kuramoto (1975) | Multiple agents share no rhythm coupling — each operates independently |
+| 6. Neuromodulatory reconfiguration | Marder (1987, 2012) | The trigger topology stays fixed regardless of task context |
+| 7. Phase-dependent response reversal | Forssberg (1979) | The same stimulus should produce different responses depending on which phase the agent occupies |
+| 9. Efference copy | von Helmholtz (1867); Sperry (1950) | The agent does not predict outcomes of its own actions or compare predictions against results |
+
+**Partial implementations** (the architecture addresses these but could strengthen them):
+
+Degeneracy — multiple pathways achieving the same function (Edelman & Gally, 2001). Sensory gating — suppressing irrelevant input during focused processing (Duysens & Pearson, 1976). Developmental maturation — components progressing from supervised to autonomous operation (Thelen, 1985). Frequency-amplitude coupling — matching processing depth to task scope (Grillner, 1985). Asymmetric oscillation — spending unequal time in different behavioral modes (Grillner, 1975). Starter/sustainer distinction — different mechanisms for entering versus maintaining a mode (Shik, Severin, & Orlovskii, 1966).
+
+**Designed but dormant:**
+
+Adaptive forgetting — de-crystallization and pruning of inactive patterns (Huttenlocher, 1979; Ebbinghaus, 1885). This one gets its own section below.
+
+
+## The Crystallized/Fluid Interface: The Unifying Insight
+
+Raymond Cattell (1963) distinguished two forms of intelligence: **crystallized intelligence** (Gc) — accumulated knowledge and learned procedures that remain stable over time — and **fluid intelligence** (Gf) — the capacity to reason adaptively in novel situations, independent of prior learning. Cattell's investment theory proposes that fluid intelligence *invests into* crystallized intelligence through experience: the fluid process leaves behind a crystallized residue that future fluid processing builds on.
+
+Pattern generators sit exactly at this interface.
+
+The **pattern specification** crystallizes — trigger definitions, firing conditions, check sequences persist in committed documentation. They encode accumulated design knowledge and produce consistent behavior across sessions. This parallels crystallized intelligence: reliable, stable, drawing on prior investment.
+
+The **pattern dynamics** remain fluid — modulation state, phase tracking, context-dependent reconfiguration emerge at runtime. They adapt to current conditions without persisting beyond the session. This parallels fluid intelligence: adaptive, context-sensitive, operating on novel input.
+
+This separation explains why some cogarch components belong in committed infrastructure while others belong in runtime context. The specification answers "what pattern should fire?" — a question with a stable answer that improves through accumulated experience. The dynamics answer "how should this pattern adapt right now?" — a question that requires current context and changes moment to moment.
+
+
+## The Five-Stage Crystallization Pipeline
+
+How does a pattern generator move from a sketch in a notebook to a structural component that runs without consuming any processing attention? The skill acquisition literature provides three convergent models:
+
+- **Fitts & Posner (1967):** cognitive → associative → autonomous
+- **Anderson ACT-R (1982):** declarative → procedural → compiled
+- **Dreyfus & Dreyfus (1980):** novice → competent → proficient → expert → mastery
+
+These converge on a single trajectory: explicit deliberation becomes implicit procedure through practice. We formalized this as a five-stage pipeline:
+
+```
+Stage 0: Concept         Ideas file — fully fluid, requires prompting to activate
+Stage 1: In-context      Agent reasons explicitly each time — fluid deliberation
+Stage 2: Trigger-encoded Fires on condition — processing within remains fluid
+Stage 3: Hook/script     Runs mechanically without consuming context window
+Stage 4: Infrastructure  Daemon or cron — the agent does not participate at all
+```
+
+Each stage reduces **energy cost** (context tokens consumed, deliberation time spent) while increasing **stability** (reliability across sessions, resistance to perturbation).
+
+**Advancement criteria** prevent premature crystallization:
+
+- **0 → 1:** Knock-on analysis (tracing consequences through 10 orders of effect) positive, plus user approval
+- **1 → 2:** Three or more sessions of successful execution without user correction
+- **2 → 3:** Five or more clean sessions, user override rate below 20%, no failure analyses attributed
+- **3 → 4:** Ten or more sessions of correct operation with consistent dynamics
+
+**Reversal** (re-fluidization) works in the opposite direction. A failure analysis drops a pattern one stage. An environment shift drops it to Stage 1 for re-adaptation. This prevents the "stiff and unbending" pathology that Laozi warned about in *Dao De Jing* Chapter 76 — systems that crystallize everything lose the adaptive capacity to handle novel conditions.
+
+A concrete example: the session-startup protocol. Early in the project, the agent manually checked memory files, read triggers, and oriented itself (Stage 1 — explicit deliberation every session). After a dozen consistent sessions, this became a trigger that fired automatically on session start (Stage 2). Eventually, it became a platform hook that runs mechanically before the agent even receives its first message (Stage 3). The pattern specification crystallized; the dynamics (which files to prioritize, what to flag) remain fluid within the hook's framework.
+
+
+## Why Order Matters: Dependency Clusters
+
+The 17 principles do not implement independently — they form five clusters where internal dependencies constrain the implementation sequence:
+
+**The Dynamical Triad** (Principles 3 + 5 + 16): Endogenous rhythmicity, entrainment, and limit cycle attractors (Strogatz, 2000) reinforce each other. Rhythms need attractors for stability; entrainment needs rhythms to couple; limit cycles need rhythmic behavior to stabilize around. Implement together or not at all.
+
+**The Mode System** (Principles 4 + 7 + 14 + 15): Mutual inhibition serves as the prerequisite — you need mode competition before you can add phase-dependent reversal, asymmetric oscillation timing, or starter/sustainer distinctions. Start with two-mode generate/evaluate alternation; layer sophistication onto that foundation.
+
+**The Safety Net** (Principles 8 + 10): Degeneracy (backup pathways) and sensory gating (suppressing irrelevant input) require co-development. Gating without degeneracy creates blind spots — if you suppress a check, you need a backup pathway that covers the same function. Gating alone produces vulnerability.
+
+**The Self-Awareness Pair** (Principles 9 + 11): Efference copy (predicting your own outputs) and developmental maturation (tracking component reliability) both extend the state database. Independent but synergistic — efference copy tracks what the agent *did*; maturation tracks how *reliably* components perform.
+
+**The Lifecycle Trio** (Principles 11 + 12 + 17): Maturation (forward crystallization), plasticity (recovery from failure), and adaptive forgetting (eventual pruning) complete the component lifecycle from birth through development, damage recovery, and retirement.
+
+
+## Adaptive Forgetting: The Necessary Complement
+
+Crystallization pipelines only address one direction — how patterns solidify. Without the reverse process, architecture accumulates dead patterns indefinitely: hooks that never activate, triggers that never fire, conventions that no longer apply.
+
+**Synaptic pruning** (Huttenlocher, 1979) provides the biological model. During development, the brain overproduces synaptic connections, then prunes unused ones — strengthening active pathways while eliminating inactive ones. The mature brain contains fewer synapses than the infant brain, but the surviving connections carry more information.
+
+**The Ebbinghaus savings effect** (1885) provides the recovery mechanism. Hermann Ebbinghaus demonstrated that forgotten material relearns faster than novel material — the structural trace persists after behavioral extinction. A person who learned Spanish ten years ago and "forgot" it relearns faster than someone starting fresh, because the neural substrate retains a residue of the original learning.
+
+Applied to AI architecture: pruned patterns do not get deleted. They move to an archive with a `[retired — {reason}]` tag. If circumstances make the pattern relevant again, re-crystallization proceeds faster than initial crystallization — the specification already exists; only the dynamics need re-adaptation.
+
+**Activation precondition:** Adaptive forgetting remains dormant (Stage 0) until the architecture reaches sufficient scale — trigger count exceeding 25, or hook count exceeding 25, or three or more dormant patterns found in a single audit. Premature pruning risks losing rare-firing patterns that carry high value when they do fire. A safety check that activates once every twenty sessions still catches critical issues every time.
+
+
+## The Design Rule
+
+The entire analysis distills into one architectural rule:
+
+> **Intra-session dynamics remain semi-crystallized (triggers, Stage 2); inter-session dynamics crystallize fully (hooks and infrastructure, Stages 3-4).**
+
+The reasoning: intra-session patterns need fluid context to operate correctly. Mode switching depends on what the agent did moments ago — which tasks completed, what problems surfaced, what the user just said. Encoding this in a rigid hook would strip the adaptive capacity that makes the pattern useful.
+
+Inter-session patterns can run from crystallized state. A heartbeat check does not need to know what happened in the last conversation. A session-start protocol applies the same orientation steps regardless of prior context. These patterns benefit from crystallization because they consume processing capacity without requiring judgment.
+
+This rule determines where each of the 17 principles belongs in the architecture — not as a design preference but as a consequence of whether the principle requires current context (semi-crystallized) or operates context-independently (fully crystallized).
+
+
+## What This Means for AI Safety
+
+The CPG framework carries direct implications for autonomous AI systems:
+
+**Maturation replaces deployment.** Instead of deploying a complete governance system at launch, components mature through supervised stages. A safety mechanism starts under full human oversight (Stage 1), graduates to semi-autonomous operation (Stage 2) only after demonstrating reliability, and reaches full autonomy (Stage 4) only after extensive verification. This mirrors how biological CPGs develop — infant locomotor patterns differ substantially from adult patterns, with maturation producing the final form (Thelen, 1985).
+
+**Forgetting prevents regulatory accumulation.** AI governance systems that only add rules and never remove them eventually collapse under their own weight — every edge case gets a new constraint, and the constraint set grows until it produces contradictions or becomes unnavigable. Systematic decay and pruning keep the governance architecture lean and coherent.
+
+**Dependency awareness prevents partial implementation.** The cluster analysis shows that implementing gating without degeneracy creates blind spots. Implementing rhythmicity without limit cycle attractors produces unstable oscillation. AI safety mechanisms that address one failure mode while ignoring its structural dependencies can create new vulnerabilities.
+
+**The coupled generators (Invariant 3) apply here too.** Creative development of new safety mechanisms and evaluative assessment of existing ones must alternate perpetually. A system that only adds safety mechanisms without evaluating their effectiveness accumulates dead weight. A system that only evaluates without creating new mechanisms falls behind novel threats.
+
+
+## The Honest Caveat
+
+Every one of these 17 principles originates from analogical reasoning — transferring properties from biological neural circuits to software agent systems. Analogy provides generative power (it surfaces possibilities that pure engineering analysis misses) but carries inherent transfer risk.
+
+Properties that hold in neural circuits may not hold in software. CPGs operate through electrochemical dynamics in physical substrate; AI triggers operate through conditional logic in a language model's context window. The structural similarity may run deep or it may remain superficial. Without empirical validation in AI agent systems, these principles function as theoretically grounded design hypotheses — productive starting points, not validated architecture.
+
+The crystallization pipeline itself lacks empirical validation in this context. Fitts and Posner (1967) studied human motor skill acquisition; Anderson (1982) modeled human memory consolidation; Dreyfus and Dreyfus (1980) characterized human expertise development. Whether these trajectories describe AI component maturation constitutes an open empirical question.
+
+What the CPG framework *does* provide: a principled, citation-grounded vocabulary for talking about how AI cognitive architecture develops over time. That vocabulary surfaces questions that static architecture descriptions cannot ask — questions about maturation, decay, dependency, and the interface between stable structure and adaptive flexibility.
+
+The generator never stops. The architecture keeps developing. Build accordingly.
+
+
+---
+
+**EPISTEMIC FLAGS**
+- All 17 principles rest on analogical transfer from biological neural circuits to software architecture. Each mapping carries transfer risk proportional to the distance between substrate types.
+- The crystallization pipeline draws on human skill acquisition research (Fitts & Posner, 1967; Anderson, 1982; Dreyfus & Dreyfus, 1980). Whether AI component maturation follows the same trajectory remains an untested assumption.
+- Dependency clusters derive from theoretical analysis of principle interactions, not from empirical implementation experience. Predicted dependencies may not manifest as expected.
+- Adaptive forgetting activation thresholds (trigger count > 25, hook count > 25) lack empirical grounding — they represent engineering judgment, not validated parameters.
+- The WEIRD limitation applies: source neuroscience literature reflects Western research traditions. Cross-cultural neuroscience (CPGs themselves appear universal across vertebrates) partially mitigates this for the biological layer but not for the psychological frameworks applied.
+
+
+---
+
+## References
+
+Anderson, J.R. (1982). Acquisition of cognitive skill. *Psychological Review*, 89(4), 369-406.
+
+Cattell, R.B. (1963). Theory of fluid and crystallized intelligence: A critical experiment. *Journal of Educational Psychology*, 54(1), 1-22.
+
+Dreyfus, S.E. & Dreyfus, H.L. (1980). *A Five-Stage Model of the Mental Activities Involved in Directed Skill Acquisition*. Operations Research Center, University of California, Berkeley.
+
+Duysens, J. & Pearson, K.G. (1976). The role of cutaneous afferents from the distal hindlimb in the regulation of the step cycle of thalamic cats. *Experimental Brain Research*, 24(3), 245-255.
+
+Ebbinghaus, H. (1885). *Uber das Gedachtnis* [On Memory]. Duncker & Humblot.
+
+Edelman, G.M. & Gally, J.A. (2001). Degeneracy and complexity in biological systems. *Proceedings of the National Academy of Sciences*, 98(24), 13763-13768.
+
+Fitts, P.M. & Posner, M.I. (1967). *Human Performance*. Brooks/Cole.
+
+Forssberg, H. (1979). Stumbling corrective reaction: A phase-dependent compensatory reaction during locomotion. *Journal of Neurophysiology*, 42(4), 936-953.
+
+Graham Brown, T. (1911). The intrinsic factors in the act of progression in the mammal. *Proceedings of the Royal Society B*, 84(572), 308-319.
+
+Grillner, S. (1975). Locomotion in vertebrates: Central mechanisms and reflex interaction. *Physiological Reviews*, 55(2), 247-304.
+
+Grillner, S. (1985). Neurobiological bases of rhythmic motor acts in vertebrates. *Science*, 228(4696), 143-149.
+
+Guilford, J.P. (1967). *The Nature of Human Intelligence*. McGraw-Hill.
+
+Huttenlocher, P.R. (1979). Synaptic density in human frontal cortex — developmental changes and effects of aging. *Brain Research*, 163(2), 195-205.
+
+Kuramoto, Y. (1975). Self-entrainment of a population of coupled non-linear oscillators. In *International Symposium on Mathematical Problems in Theoretical Physics*. Springer.
+
+Laozi. (c. 4th century BCE). *Dao De Jing* [Tao Te Ching].
+
+Marder, E. (1987). Neurotransmitter modulation of neuronal circuits. In *Proceedings of the International Conference on Neural Networks*. IEEE.
+
+Marder, E. (2012). Neuromodulation of neuronal circuits: Back to the future. *Neuron*, 76(1), 1-11.
+
+Nijstad, B.A., De Dreu, C.K.W., Rietzschel, E.F., & Baas, M. (2010). The dual pathway to creativity model. *European Review of Social Psychology*, 21(1), 34-77.
+
+Shik, M.L., Severin, F.V., & Orlovskii, G.N. (1966). Control of walking and running by means of electrical stimulation of the midbrain. *Biophysics*, 11, 756-765.
+
+Sperry, R.W. (1950). Neural basis of the spontaneous optokinetic response produced by visual inversion. *Journal of Comparative and Physiological Psychology*, 43(6), 482-489.
+
+Strogatz, S.H. (2000). From Kuramoto to Crawford: Exploring the onset of synchronization in populations of coupled oscillators. *Physica D*, 143(1-4), 1-20.
+
+Thelen, E. (1985). Developmental origins of motor coordination: Leg movements in human infants. *Developmental Psychobiology*, 18(1), 1-22.
+
+von Helmholtz, H. (1867). *Handbuch der physiologischen Optik* [Handbook of Physiological Optics]. Voss.
+
+von Holst, E. (1939). Die relative Koordination als Phanomen und als Methode zentralnervoser Funktionsanalyse [Relative coordination as phenomenon and method of CNS functional analysis]. *Ergebnisse der Physiologie*, 42, 228-306.


### PR DESCRIPTION
## Summary
- Expanded CPG pattern generators blog post (~250 lines, up from 170-line original)
- Adds: dependency clusters, adaptive forgetting (Ebbinghaus savings), design rule (intra/inter-session), AI safety implications, epistemic flags
- Five-persona lensFraming (voter/politician/educator/researcher/developer)
- Zero E-Prime violations
- Supersedes 2026-03-13-pattern-generators.md (prior version kept for reference)

## Review requested
Five-persona adversarial review per blog publication protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)